### PR TITLE
Corrected SlackNotification property name for 'config'

### DIFF
--- a/SlackNotification.groovy
+++ b/SlackNotification.groovy
@@ -78,12 +78,12 @@ def sendMessage(String url, Map message) {
  * @param color the color for the message
  */
 def triggerMessage(Map execution, Map config, String defaultColor) {
-    if (configuration.proxyHost != null && configuration.proxyPort != null) {
-        System.err.println("DEBUG: proxyHost="+configuration.proxyHost)
-        System.err.println("DEBUG: proxyPort="+configuration.proxyPort)
+    if (config.proxyHost != null && config.proxyPort != null) {
+        System.err.println("DEBUG: proxyHost="+config.proxyHost)
+        System.err.println("DEBUG: proxyPort="+config.proxyPort)
         System.getProperties().put("proxySet", "true")
-        System.getProperties().put("proxyHost", configuration.proxyHost)
-        System.getProperties().put("proxyPort", configuration.proxyPort)
+        System.getProperties().put("proxyHost", config.proxyHost)
+        System.getProperties().put("proxyPort", config.proxyPort)
     }
     def expandedTitle = expandString(config.title, [execution: execution])
     def expandedText = expandString(config.additionalText, [execution: execution])


### PR DESCRIPTION
I corrected the SlackNotification object property "configuration" to "config" to avoid the following errors:

2018-01-24 12:08:45,761 [quartzScheduler_Worker-1] ERROR grails.app.services.rundeck.services.NotificationService - Error sending notification: Notification{eventTrigger='onsuccess', type='SlackNotification', content='{"title":"${job.Status} [${job.project}] ${job.fullName} run by ${job.username} (#${job.execid})","channel":"#rundeck","optionFields":"","includeFailedNodes":"true","_includeFailedNodes":"","additionalText":"","color":""}'}: class groovy.lang.MissingPropertyException: No such property: configuration for class: SlackNotification
groovy.lang.MissingPropertyException: No such property: configuration for class: SlackNotification
